### PR TITLE
Fixed ip_address typo

### DIFF
--- a/woopra/__init__.py
+++ b/woopra/__init__.py
@@ -43,7 +43,7 @@ class WoopraTracker:
 		self.cookie = cookie
 
 	def set_ip_address(self, ip_address):
-		self.ip_addres = ip_address
+		self.ip_address = ip_address
 
 	def set_user_agent(self, user_agent):
 		self.user_agent = user_agent


### PR DESCRIPTION
There was a typo in the set_ip_address function that set the variable ip_addres to the IP, not ip_address.